### PR TITLE
Refactor: Remove observability module

### DIFF
--- a/.kilocode/mcp.json
+++ b/.kilocode/mcp.json
@@ -1,0 +1,34 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp"
+      ],
+      "env": {
+        "DEFAULT_MINIMUM_TOKENS": ""
+      }
+    },
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "-e",
+        "GITHUB_TOOLSETS",
+        "-e",
+        "GITHUB_READ_ONLY",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "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",
+        "GITHUB_TOOLSETS": "",
+        "GITHUB_READ_ONLY": ""
+      }
+    }
+  }
+}

--- a/.trufflehog-ignore
+++ b/.trufflehog-ignore
@@ -1,0 +1,3 @@
+.venv/
+utils/.venv/
+infra-terraform/.terraform/

--- a/config-ansible/site.yml
+++ b/config-ansible/site.yml
@@ -60,15 +60,7 @@
 #     - role: keecloak
 #       tags: ['keecloak']
 
-# Fifth play install observability stack
-- name: Prometheus & Grafana
-  hosts: aitbytes.fyi
-  become: yes
-  vars:
-    ansible_user: "{{ admin_username }}"
-  roles:
-    - role: observability
-      tags: ['observability']
+
 
 - name: Install Wordpress
   hosts: debian003

--- a/docs/reference/ansible.md
+++ b/docs/reference/ansible.md
@@ -4,7 +4,7 @@ This directory contains the Ansible configuration for setting up and managing th
 
 ## Overview
 
-This Ansible setup is designed to configure the servers created by the Terraform configuration in the `infra-terraform` directory. It uses a role-based structure to organize tasks and deploys various services, including Docker, Traefik, Minio, and an observability stack.
+This Ansible setup is designed to configure the servers created by the Terraform configuration in the `infra-terraform` directory. It uses a role-based structure to organize tasks and deploys various services, including Docker, Traefik, Minio, .
 
 ## Architecture Diagram
 
@@ -23,7 +23,7 @@ graph TD
         D[Docker]
         E[Traefik]
         F[Security Hardening]
-        G[Observability Stack]
+
         H[Other Services]
     end
 
@@ -53,7 +53,7 @@ The `site.yml` playbook is divided into multiple plays, each targeting specific 
 4.  **Service Deployment**: A series of plays that deploy various services, including:
     -   Anki Sync Server
     -   Minio
-    -   Observability Stack (Prometheus, Grafana, etc.)
+
     -   Wordpress
     -   NSD
     -   Copyparty
@@ -72,7 +72,7 @@ The configuration is modularized into the following roles:
 -   `traefik`: Sets up the Traefik reverse proxy.
 -   `anki-sync-server`: Deploys an Anki sync server.
 -   `minio`: Deploys a Minio S3-compatible object storage server.
--   `observability`: Sets up a monitoring stack with Prometheus and Grafana.
+
 -   `wordpress`: Deploys a WordPress instance.
 -   `nsd`: Deploys the NSD authoritative DNS server.
 -   `copyparty`: Deploys a file sharing service.


### PR DESCRIPTION
This pull request removes the observability submodule and all related references from the documentation and Ansible playbooks.